### PR TITLE
Proper 2D HeldNote and Default Notespeed

### DIFF
--- a/src/ReplicatedStorage/Reducers/OptionsReducer.lua
+++ b/src/ReplicatedStorage/Reducers/OptionsReducer.lua
@@ -15,7 +15,7 @@ local defaultState = {
         Keybind4 = Enum.KeyCode.P,
 
         AudioOffset = 0;
-        NoteSpeed = 1;
+        NoteSpeed = 15;
         FOV = 70;
         LaneCover = 0;
 

--- a/src/ReplicatedStorage/RobeatsGameCore/NoteTypes/HeldNote2D.lua
+++ b/src/ReplicatedStorage/RobeatsGameCore/NoteTypes/HeldNote2D.lua
@@ -124,23 +124,24 @@ function HeldNote2D:new(
 		
 		if _did_trigger_head then
 			if _game._audio_manager:get_current_time_ms() > _hit_time_ms then
-				head_pos = 1
+				if _state ~= HeldNote2D.State.HoldMissedActive then
+					head_pos = 1
+				end
 			end
 		end
 		
 		_head.Position = UDim2.new(0.5, 0, head_pos, 0)
 		_tail.Position = UDim2.new(0.5, 0, tail_pos, 0)
 
-		local tail_to_head = (_head.Position.Y.Scale-_tail.Position.Y.Scale)
+		local tail_to_head = (head_pos - tail_pos)
 		
 		if _state == HeldNote2D.State.Pre then
 			_head.Visible = true
-		else
-			_head.Visible = false
 		end
 		
 		if _state == HeldNote2D.State.Passed and _did_trigger_tail then
 			_tail.Visible = false
+			_head.Visible = false
 		else
 			if tail_visible() then
 				_tail.Visible = true
@@ -159,6 +160,9 @@ function HeldNote2D:new(
 		local imm = false
 		if _state == HeldNote2D.State.HoldMissedActive then
 			target_transparency = 0.9
+			if _did_trigger_head then
+				_head.Visible = false
+			end
 
 		elseif _state == HeldNote2D.State.Passed and _did_trigger_tail then
 			target_transparency = 1
@@ -170,9 +174,17 @@ function HeldNote2D:new(
 		
 		if imm then
 			_body.BackgroundTransparency = target_transparency
+			_tail.BackgroundTransparency = target_transparency
 		else
 			_body.BackgroundTransparency = CurveUtil:Expt(
 				_body.BackgroundTransparency,
+				target_transparency,
+				CurveUtil:NormalizedDefaultExptValueInSeconds(0.15),
+				dt_scale
+			)
+
+			_tail.BackgroundTransparency = CurveUtil:Expt(
+				_tail.BackgroundTransparency,
 				target_transparency,
 				CurveUtil:NormalizedDefaultExptValueInSeconds(0.15),
 				dt_scale


### PR DESCRIPTION
Like in osu!mania
- Head still visible when holding
- Head and length become what should be like if missed
- and Tail become invisible too when head missed