### PR TITLE
Reduce max playback rate from 5x to 2x

### DIFF
--- a/src/ReplicatedStorage/UI/Screens/SongSelect/init.lua
+++ b/src/ReplicatedStorage/UI/Screens/SongSelect/init.lua
@@ -36,8 +36,12 @@ function SongSelect:init()
 
     self.maid = Maid.new()
 
+    if self.props.options.SongRate > 200 then
+        self.props.setSongRate(200)
+    end
+
     self.uprate = function()
-        if self.props.options.SongRate < 500 then
+        if self.props.options.SongRate < 200 then
             self.props.setSongRate(self.props.options.SongRate + 5)
         end
     end


### PR DESCRIPTION
This is needed to follow legacy's maximum rate (which is 2x) and reduce possibility macro or other abuse method to gain ranks.

The changes already tested and already live in-game