### PR TITLE
Replace old note arrival calculation with new one

### DIFF
--- a/src/ReplicatedStorage/RobeatsGameCore/AudioManager.lua
+++ b/src/ReplicatedStorage/RobeatsGameCore/AudioManager.lua
@@ -289,6 +289,8 @@ function AudioManager:new(_game)
 	local _ended_connection = nil
 
 	function self:update(dt_scale)
+		_note_prebuffer_time = 13720 / _game._config.NoteSpeed
+
 		if _current_mode == AudioManager.Mode.PreStart then
 			--Do pre-start countdown
 			local pre_start_time_pre = _pre_start_time_ms

--- a/src/ReplicatedStorage/RobeatsGameCore/NoteTypes/HeldNote.lua
+++ b/src/ReplicatedStorage/RobeatsGameCore/NoteTypes/HeldNote.lua
@@ -135,7 +135,7 @@ function HeldNote:new(
 		return SPUtil:vec3_lerp(
 			get_start_position(),
 			get_end_position(),
-			(_game._audio_manager:get_current_time_ms() - _creation_time_ms) / (_hit_time_ms - _creation_time_ms)
+			math.clamp(1 - (_hit_time_ms - _game._audio_manager:get_current_time_ms()) / _game._audio_manager:get_note_prebuffer_time_ms(), 0, 9999) -- YOLO
 		)
 	end
 	
@@ -148,8 +148,7 @@ function HeldNote:new(
 	end
 	
 	local function get_tail_t()
-		local tail_show_time = _game._audio_manager:get_current_time_ms() - get_tail_hit_time() + _game._audio_manager:get_note_prebuffer_time_ms()
-		return tail_show_time / _game._audio_manager:get_note_prebuffer_time_ms()
+		return 1 - (get_tail_hit_time() - _game._audio_manager:get_current_time_ms()) / _game._audio_manager:get_note_prebuffer_time_ms()
 	end
 	
 	local function get_tail_position()
@@ -160,7 +159,7 @@ function HeldNote:new(
 			return SPUtil:vec3_lerp(
 				get_start_position(),
 				get_end_position(),
-				tail_t
+				math.clamp(tail_t, 0, 9999) -- SAME YOLO
 			)
 		end
 	end

--- a/src/ReplicatedStorage/RobeatsGameCore/NoteTypes/HeldNote2D.lua
+++ b/src/ReplicatedStorage/RobeatsGameCore/NoteTypes/HeldNote2D.lua
@@ -93,7 +93,7 @@ function HeldNote2D:new(
 	end	
 	
 	local function get_head_position()
-		return (_game_audio_manager_get_current_time_ms - _creation_time_ms) / (_hit_time_ms - _creation_time_ms)
+		return 1 - (_hit_time_ms - _game._audio_manager:get_current_time_ms()) / _game._audio_manager:get_note_prebuffer_time_ms()
 	end
 	
 	local function get_tail_hit_time()
@@ -105,8 +105,7 @@ function HeldNote2D:new(
 	end
 	
 	local function get_tail_t()
-		local tail_show_time = _game._audio_manager:get_current_time_ms() - get_tail_hit_time() + _game._audio_manager:get_note_prebuffer_time_ms()
-		return tail_show_time / _game._audio_manager:get_note_prebuffer_time_ms()
+		return 1 - (get_tail_hit_time() - _game._audio_manager:get_current_time_ms()) / _game._audio_manager:get_note_prebuffer_time_ms()
 	end
 	
 	local function get_tail_position()

--- a/src/ReplicatedStorage/RobeatsGameCore/NoteTypes/SingleNote.lua
+++ b/src/ReplicatedStorage/RobeatsGameCore/NoteTypes/SingleNote.lua
@@ -113,8 +113,9 @@ function SingleNote:new(_game, _track_index, _slot_index, _creation_time_ms, _hi
 	
 	--[[Override--]] function self:update(dt_scale)
 		if _state == SingleNote.State.Pre then
-			_t = (_game._audio_manager:get_current_time_ms() - _creation_time_ms) / (_hit_time_ms - _creation_time_ms)
-			
+			--_t = (_game._audio_manager:get_current_time_ms() - _creation_time_ms) / (_hit_time_ms - _creation_time_ms)
+			_t = math.clamp(1 - (_hit_time_ms - _game._audio_manager:get_current_time_ms()) / _game._audio_manager:get_note_prebuffer_time_ms(), 0, 9999)
+
 			self:update_visual(dt_scale)
 			
 			if self:should_remove(_game) then

--- a/src/ReplicatedStorage/RobeatsGameCore/NoteTypes/SingleNote2D.lua
+++ b/src/ReplicatedStorage/RobeatsGameCore/NoteTypes/SingleNote2D.lua
@@ -68,8 +68,9 @@ function SingleNote2D:new(_game, _track_index, _slot_index, _creation_time_ms, _
 	
 	--[[Override--]] function self:update(dt_scale)
 		if _state == SingleNote2D.State.Pre then
-			_t = (_game._audio_manager:get_current_time_ms() - _creation_time_ms) / (_hit_time_ms - _creation_time_ms)
-			
+			--_t = (_game._audio_manager:get_current_time_ms() - _creation_time_ms) / (_hit_time_ms - _creation_time_ms)
+			_t = 1 - (_hit_time_ms - _game._audio_manager:get_current_time_ms()) / _game._audio_manager:get_note_prebuffer_time_ms()
+
 			self:update_visual(_t)
 			
 			if self:should_remove() then

--- a/src/ReplicatedStorage/RobeatsGameCore/RobeatsGame.lua
+++ b/src/ReplicatedStorage/RobeatsGameCore/RobeatsGame.lua
@@ -192,6 +192,13 @@ function RobeatsGame:new(_game_environment_center_position, _config)
 
 		if _current_mode == RobeatsGame.Mode.Game then
 			self._audio_manager:update(dt_scale)
+
+			-- if self._input:control_just_pressed(InputUtil.KEY_SPEEDUP) then
+			-- 	self._config.NoteSpeed += 1
+			-- elseif self._input:control_just_pressed(InputUtil.KEY_SPEEDDOWN) then
+			-- 	self._config.NoteSpeed -= 1
+			-- end
+
 			if replay.viewing then
 				local actions = replay:get_actions_this_frame(self._audio_manager:get_current_time_ms(true))
 

--- a/src/ReplicatedStorage/Shared/InputUtil.lua
+++ b/src/ReplicatedStorage/Shared/InputUtil.lua
@@ -12,6 +12,9 @@ InputUtil.KEY_TRACK2 = 1
 InputUtil.KEY_TRACK3 = 2
 InputUtil.KEY_TRACK4 = 3
 
+InputUtil.KEY_SPEEDUP = 80
+InputUtil.KEY_SPEEDDOWN = 81
+
 InputUtil.KEY_DOWN = 11
 InputUtil.KEY_LEFT = 12
 InputUtil.KEY_RIGHT = 13
@@ -304,6 +307,14 @@ function InputUtil:new()
 			else
 				active_dict:contains(InputUtil.KEYCODE_TOUCH_TRACK4) or
 				active_dict:contains(keybinds[4])
+
+		-- elseif control == InputUtil.KEY_SPEEDUP then
+		-- 	return active_dict:contains(InputUtil.KEY_SPEEDUP) or
+		-- 		active_dict:contains(Enum.KeyCode.Nine)
+
+		-- elseif control == InputUtil.KEY_SPEEDDOWN then
+		-- 	return active_dict:contains(InputUtil.KEY_SPEEDDOWN) or
+		-- 		active_dict:contains(Enum.KeyCode.Zero)
 
 		-- I wonder what these keys are for?
 		elseif control == InputUtil.KEYCODE_TOUCH_TRACK1 then


### PR DESCRIPTION
This might fix "note jump" when lag spikes, this commit also add ability to change notespeed in-game

TODO:
While adding ability to change, changing in-mid game to very low notespeed can cause all note objects rendered at once which can cause lag. maybe add object counter and use max object that can be rendered?

Live demo at: <https://www.roblox.com/games/14112392475/>
At demo place: press 9 or 0 to increase/decrease the notespeed